### PR TITLE
fixed issues with VersionUtil on 1.18.2

### DIFF
--- a/src/main/java/com/github/unldenis/hologram/util/VersionUtil.java
+++ b/src/main/java/com/github/unldenis/hologram/util/VersionUtil.java
@@ -31,9 +31,8 @@ public class VersionUtil {
     static {
         String bpName = Bukkit.getServer().getClass().getPackage().getName();
         VERSION = bpName.substring(bpName.lastIndexOf(".") + 1);
-
         String clean = VERSION.substring(0, VERSION.length() - 3);
-        CLEAN_VERSION = VersionUtil.VersionEnum.valueOf(clean);
+        CLEAN_VERSION = VersionUtil.VersionEnum.valueOf(clean.toUpperCase());
     }
 
     public static boolean isCompatible(@NotNull VersionEnum ve){
@@ -66,7 +65,7 @@ public class VersionUtil {
         V1_16(9),
         V1_17(10),
         V1_18(11),
-        v1_19(12);
+        V1_19(12);
 
         private final int order;
 


### PR DESCRIPTION
I'm using the library on 1.18.2. I was getting the IllegalArgumentException in VersionUtil line 58 (When it was using VersionEnum#valueOf). The string that was being passed through was "v1.18" instead of "V1.18". Fixed this by ensuring that the string is always uppercased. Also fixed VersionEnum 1.19 constant (Changed from "v1.19" to "V1.19" to mimic the rest of the constants)